### PR TITLE
Improved default environment

### DIFF
--- a/include/configs/mx6_cubox-i.h
+++ b/include/configs/mx6_cubox-i.h
@@ -186,7 +186,7 @@
         "mmcargs=setenv bootargs console=${console},${baudrate} " \
                 "root=${mmcroot};\0" \
         "loadbootscript=" \
-                "load mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
+                "load mmc ${mmcdev}:${mmcpart} ${loadaddr} ${file_prefix}${script};\0" \
         "bootscript=echo Running bootscript from mmc ...; " \
                 "source;\0" \
         "autodetectfdt=if test ${cpu} = 6SOLO || test ${cpu} = 6DL; then " \


### PR DESCRIPTION
Please consider the following commits to improve the default U-Boot environment on the CuBox-i:
- add support for loading ramdisks automatically
- use the prefix search for bootscripts

These are preconditions for u-boot working out of the box with generic distro kernels; while such don't exist yet that support CuBox-i, I'm hoping they will soon :)
